### PR TITLE
[FEATURE] Add ability to lazily instantiate underlying streams with 'pause' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,29 @@ looking for a detailed description. The only difference is that a
 make much sense to create one if you planned to stop reading at a predetermined
 point!
 
-It takes one unique configuration option, `timeout`. This specifies the amount
-of time in milliseconds that should elapse before a file is considered to have
-'finished' tailing. If omitted, it defaults to 5000ms. If set to a falsy value,
-the timeout is disabled and the stream will wait indefinitely for new content to
-arrive. Beware: if the timeout is set too low (say, to 1ms), the stream could
-very well close files that are still being written to if 'data' events don't
-come in quickly enough.
+### TailingReadableStream Constructor ###
+It takes two unique configuration options, `timeout` and `pause`. 
 
-If a timeout occurs, an `end` event is sent to replicate the file closing.
+**timeout**
+
+ * A Number that specifies the amount of time in milliseconds that should elapse before a file 
+ is considered to have 'finished' tailing. If omitted, it defaults to 5000ms. If 
+ set to a falsy value, the timeout is disabled and the stream will wait indefinitely
+ for new content to arrive. Beware: if the timeout is set too low (say, to 1ms), 
+ the stream could very well close files that are still being written to if 'data' 
+ events don't come in quickly enough.
+
+* If a timeout occurs, an `end` event is sent to replicate the file closing.
+
+**startPaused**
+
+* A Boolean that when set to `true` will prevent the underlying stream from immediately 
+instantiating in addition to preventing `fs.watch` from emitting `data` events. Defaults
+to `false`.
+
+* _NOTE_: If this option is set to `true` you must call `resume()` on your stream object 
+in order to lazily instantiate the underlying stream and begin watching it for changes. 
+
 
 ## Implementation ##
 Internally, `TailingReadableStream` uses the

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
         "email": "jasontbradshaw@gmail.com",
         "url": "http://jasontbradshaw.com/"
     },
+    "contributors": [{
+        "name": "Nick Arnold",
+        "email": "nicholasjarnold@gmail.com",
+        "url": "https://nickarnold.name"
+    }],
     "description": "Read a growing file continuously as a Stream.",
     "version": "0.0.4",
     "keywords": [

--- a/tailing-stream.js
+++ b/tailing-stream.js
@@ -14,10 +14,10 @@ var extend = function (preserveExistingProperties) {
     }
 
     for (prop in obj) {
-      if (Object.hasOwnProperty(obj, prop)) {
+      if (Object.prototype.hasOwnProperty.call(obj, prop)) {
         // preserve preexisting child properties if specified
         if (preserveExistingProperties &&
-            Object.hasOwnProperty(result, prop)) {
+            Object.prototype.hasOwnProperty.call(result, prop)) {
               continue;
             }
         result[prop] = obj[prop];
@@ -66,13 +66,18 @@ TailingReadableStream.open = function (path, options) {
   var file = new TailingReadableStream();
 
   // override the timeout if present in options
-  if (Object.hasOwnProperty(options, 'timeout')) {
+  if (Object.prototype.hasOwnProperty.call(options, 'timeout')) {
     file.timeout = options.timeout;
   }
 
   // set the reading start point if specified
-  if (Object.hasOwnProperty(options, 'start')) {
+  if (Object.prototype.hasOwnProperty.call(options, 'start')) {
     file._offset = options.start;
+  }
+
+  // do not start emitting data events if specified and true
+  if (Object.prototype.hasOwnProperty.call(options, 'startPaused')) {
+    file._paused = options.startPaused;
   }
 
   // store options for use when opening ReadableStreams, sans 'end'
@@ -80,7 +85,9 @@ TailingReadableStream.open = function (path, options) {
   delete file._read_stream_options.end;
 
   file._path = path;
-  file._watch();
+  if (!file._paused) {
+    file._watch();
+  }
 
   return file;
 };


### PR DESCRIPTION
@jasontbradshaw

Adds the ability to supply a `pause` option to the constructor that can be used to lazily instantiate the underlying stream by preventing the `_watch` method from being executed until a `resume()` is called. This is useful in situations where one may initialize the tailing stream object before needing to use it elsewhere. 

I also fixed a bug in the way the code was merging and recognizing options by changing all instances of `Object.hasOwnProperty(someInstance, 'propertyName')` to `someInstance.hasOwnProperty('propertyName')`. 

The readme was updated to reflect the `pause` option, too.

Thanks for putting this together, BTW. It saved some time and taught me a bit about node streams. Cheers.
