### PR TITLE
check for watcher on pause

### DIFF
--- a/tailing-stream.js
+++ b/tailing-stream.js
@@ -163,8 +163,10 @@ TailingReadableStream.prototype.pause = function () {
     this._paused = true;
 
     // stop watching the file (restarts when resume is called)
-    this._watcher.close();
-    this._watcher = null;
+    if (this._watcher) {
+      this._watcher.close();
+      this._watcher = null;
+    }
 
     // clear the timeout kill switch
     clearTimeout(this._timeoutId);


### PR DESCRIPTION
I've gotten in weird edge cases where the stream will pause before the watcher is created. This adds a check to make sure the watcher exists before calling `.close()` on `null`;