### PR TITLE
Change Stream to Readable

### DIFF
--- a/tailing-stream.js
+++ b/tailing-stream.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var Stream = require('stream').Stream;
+var Readable = require('stream').Readable;
 
 // copy properties from right-most args to left-most
 var extend = function (preserveExistingProperties) {
@@ -29,8 +29,8 @@ var extend = function (preserveExistingProperties) {
 }
 
 var TailingReadableStream = function () {
-  // run Stream's init code on us, since we're a Stream
-  Stream.call(this);
+  // run Readable's init code on us, since we're a Readable
+  Readable.call(this);
 
   // whether the stream can be read from
   this.readable = true;
@@ -50,14 +50,14 @@ var TailingReadableStream = function () {
   this._paused = false;
 };
 
-// 'inherit' from Stream
-TailingReadableStream.prototype = Object.create(Stream.prototype, {
+// 'inherit' from Readable
+TailingReadableStream.prototype = Object.create(Readable.prototype, {
   constructor: {
     value: TailingReadableStream,
   enumerable: false
   }
 });
-extend(true, TailingReadableStream, Stream);
+extend(true, TailingReadableStream, Readable);
 
 // create a new TailingReadableStream and return it
 TailingReadableStream.open = function (path, options) {


### PR DESCRIPTION
First, thanks for this library.  It saved me a lot of time not having to build it myself.  Most other "tail" libraries don't handle binary data as they are designed for tailing logs, so I was happy to find your code.

I am submitting this PR because there are several methods in Stream.Readable that are not part of Stream directly.  When you inherit from Stream, these methods are not part of the TailingReadableStream prototype.  For example, unpipe() is undefined in your current master (which is how I discovered this).  I also took a look at the Node.js source code for [fs.createReadStream()](https://github.com/nodejs/node/blob/master/lib/fs.js#L1746) to verify that it uses Readable and it does.
